### PR TITLE
Remove unused startElement from Moozak_scene1 constructor().

### DIFF
--- a/js/music/moozak_scene1.js
+++ b/js/music/moozak_scene1.js
@@ -1,5 +1,5 @@
 class Moozak_scene1 {
-    constructor(startElement){
+    constructor(){
         this.actx = new (window.AudioContext || window.webkitAudioContext)()
         this.interacting = false
         this.tempo = 70


### PR DESCRIPTION
```javascript
class Moozak_scene1 {
    constructor(startElement){
        //...
```
is now 
```javascript
class Moozak_scene1 {
    constructor(){
        //...
```

`startElement` was never used in the constructor nor was an argument passed to `new Moozak_scene1()` in any of the source files.